### PR TITLE
Change baggage items adding order

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -267,16 +267,14 @@ namespace Microsoft.AspNetCore.Hosting
                 // We expect baggage to be empty by default
                 // Only very advanced users will be using it in near future, we encourage them to keep baggage small (few items)
                 string[] baggage = headers.GetCommaSeparatedValues(HeaderNames.CorrelationContext);
-                if (baggage.Length > 0)
+
+                // AddBaggage adds items at the beginning  of the list, so we need to add them in reverse to keep the same order as the client
+                // An order could be important if baggage has two items with the same key (that is allowed by the contract)
+                for (var i = baggage.Length - 1; i >= 0; i--)
                 {
-                    // AddBaggage adds items at the beginning  of the list, so we need to add them in reverse to keep the same order as the client
-                    // An order could be important if baggage has two items with the same key (that is allowed by the contract)
-                    for (var i = baggage.Length - 1; i >= 0; i--)
+                    if (NameValueHeaderValue.TryParse(baggage[i], out var baggageItem))
                     {
-                        if (NameValueHeaderValue.TryParse(baggage[i], out var baggageItem))
-                        {
-                            activity.AddBaggage(baggageItem.Name.ToString(), HttpUtility.UrlDecode(baggageItem.Value.ToString()));
-                        }
+                        activity.AddBaggage(baggageItem.Name.ToString(), HttpUtility.UrlDecode(baggageItem.Value.ToString()));
                     }
                 }
             }

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -269,9 +269,11 @@ namespace Microsoft.AspNetCore.Hosting
                 string[] baggage = headers.GetCommaSeparatedValues(HeaderNames.CorrelationContext);
                 if (baggage.Length > 0)
                 {
-                    foreach (var item in baggage)
+                    // AddBaggage adds items at the beginning  of the list, so we need to add them in reverse to keep the same order as the client
+                    // An order could be important if baggage has two items with the same key (that is allowed by the contract)
+                    for (var i = baggage.Length - 1; i >= 0; i--)
                     {
-                        if (NameValueHeaderValue.TryParse(item, out var baggageItem))
+                        if (NameValueHeaderValue.TryParse(baggage[i], out var baggageItem))
                         {
                             activity.AddBaggage(baggageItem.Name.ToString(), HttpUtility.UrlDecode(baggageItem.Value.ToString()));
                         }

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
         }
         
         [Fact]
-        public void ActivityParentIdAndBaggePreservesItemsOrder()
+        public void ActivityBaggagePreservesItemsOrder()
         {
             var diagnosticListener = new DiagnosticListener("DummySource");
             var hostingApplication = CreateApplication(out var features, diagnosticListener: diagnosticListener);
@@ -322,7 +322,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
                 Headers = new HeaderDictionary()
                 {
                     {"Request-Id", "ParentId1"},
-                    {"Correlation-Context", "Key1=value1, Key2=value2, Key1=value3"}
+                    {"Correlation-Context", "Key1=value1, Key2=value2, Key1=value3"} // duplicated keys allowed by the contract
                 }
             });
             hostingApplication.CreateContext(features);

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             Assert.Contains(Activity.Current.Baggage, pair => pair.Key == "Key1" && pair.Value == "value1");
             Assert.Contains(Activity.Current.Baggage, pair => pair.Key == "Key2" && pair.Value == "value2");
         }
-        
+
         [Fact]
         public void ActivityBaggagePreservesItemsOrder()
         {
@@ -327,7 +327,7 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             });
             hostingApplication.CreateContext(features);
             Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", Activity.Current.OperationName);
-            
+
             var expectedBaggage = new []
             {
                 KeyValuePair.Create("Key1","value1"),

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -327,10 +327,15 @@ namespace Microsoft.AspNetCore.Hosting.Tests
             });
             hostingApplication.CreateContext(features);
             Assert.Equal("Microsoft.AspNetCore.Hosting.HttpRequestIn", Activity.Current.OperationName);
-            Assert.Collection(Activity.Current.Baggage, 
-                              pair => pair.Key == "Key1" && pair.Value == "value1",
-                              pair => pair.Key == "Key2" && pair.Value == "value2",
-                              pair => pair.Key == "Key1" && pair.Value == "value3");
+            
+            var expectedBaggage = new []
+            {
+                KeyValuePair.Create("Key1","value1"),
+                KeyValuePair.Create("Key2","value2"),
+                KeyValuePair.Create("Key1","value3")
+            };
+
+            Assert.Equal(expectedBaggage, Activity.Current.Baggage);
         }
 
         [Fact]


### PR DESCRIPTION
AddBaggage adds items at the beginning of the list, so we need to add them in reverse to keep the same order as the client
An order could be important if baggage has two items with the same key (that is allowed by the contract)

<!--
Addresses #bugnumber (in this specific format)
-->